### PR TITLE
feat(FE-4): Billing Checkout/Portal

### DIFF
--- a/src/app/layouts/PrivateLayout.test.tsx
+++ b/src/app/layouts/PrivateLayout.test.tsx
@@ -1,13 +1,19 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { PrivateLayout } from './PrivateLayout';
 import { ROUTES } from '@/shared/config/routes';
 import { useAuthStore } from '@/stores/authStore';
-import { QueryClient } from '@tanstack/react-query';
+import React from 'react';
 
 const mockNavigate = vi.fn();
-const mockQueryClient = new QueryClient();
+const mockQueryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: false },
+    mutations: { retry: false },
+  },
+});
 
 // Mock pour Outlet et useNavigate
 vi.mock('react-router-dom', async () => {
@@ -29,45 +35,98 @@ vi.mock('@tanstack/react-query', async () => {
   );
   return {
     ...actual,
-    useQueryClient: () => mockQueryClient,
+    useQueryClient: (): QueryClient => mockQueryClient,
   };
 });
+
+// Mock pour les hooks billing
+vi.mock('@/features/billing/hooks/useCheckout', () => ({
+  useCheckout: (): {
+    startCheckout: ReturnType<typeof vi.fn>;
+    isPending: boolean;
+    error: Error | null;
+  } => ({
+    startCheckout: vi.fn(),
+    isPending: false,
+    error: null,
+  }),
+}));
+
+vi.mock('@/features/billing/hooks/usePortal', () => ({
+  usePortal: (): {
+    openPortal: ReturnType<typeof vi.fn>;
+    isPending: boolean;
+    error: Error | null;
+  } => ({
+    openPortal: vi.fn(),
+    isPending: false,
+    error: null,
+  }),
+}));
+
+// Mock pour useAuthStore
+const mockAuthStoreState: {
+  token: string | null;
+  hasHydrated: boolean;
+  logout: ReturnType<typeof vi.fn>;
+  getToken: () => string | null;
+} = {
+  token: 'test-token',
+  hasHydrated: true,
+  logout: vi.fn(),
+  getToken: () => mockAuthStoreState.token,
+};
+
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: vi.fn(
+    (selector: (state: typeof mockAuthStoreState) => unknown) => {
+      if (typeof selector === 'function') {
+        return selector(mockAuthStoreState);
+      }
+      return selector;
+    }
+  ),
+}));
+
+const wrapper = ({ children }: { children: React.ReactNode }): JSX.Element => (
+  <QueryClientProvider client={mockQueryClient}>
+    <MemoryRouter>{children}</MemoryRouter>
+  </QueryClientProvider>
+);
 
 describe('PrivateLayout', () => {
   beforeEach(() => {
     // Reset store
-    useAuthStore.setState({ token: 'test-token', hasHydrated: true });
+    mockAuthStoreState.token = 'test-token';
+    mockAuthStoreState.hasHydrated = true;
+    mockAuthStoreState.logout = vi.fn();
     vi.clearAllMocks();
     mockNavigate.mockClear();
+    (useAuthStore as ReturnType<typeof vi.fn>).mockImplementation(
+      (selector: (state: typeof mockAuthStoreState) => unknown) => {
+        if (typeof selector === 'function') {
+          return selector(mockAuthStoreState);
+        }
+        return selector;
+      }
+    );
   });
 
   it('devrait afficher la navigation avec Dashboard', () => {
-    render(
-      <MemoryRouter>
-        <PrivateLayout />
-      </MemoryRouter>
-    );
+    render(<PrivateLayout />, { wrapper });
 
     expect(screen.getByText('Dashboard')).toBeInTheDocument();
     expect(screen.getByText('Déconnexion')).toBeInTheDocument();
   });
 
   it('devrait afficher Outlet', () => {
-    render(
-      <MemoryRouter>
-        <PrivateLayout />
-      </MemoryRouter>
-    );
+    render(<PrivateLayout />, { wrapper });
 
     expect(screen.getByTestId('outlet')).toBeInTheDocument();
   });
 
   it('devrait avoir un lien vers Dashboard', () => {
-    render(
-      <MemoryRouter>
-        <PrivateLayout />
-      </MemoryRouter>
-    );
+    render(<PrivateLayout />, { wrapper });
 
     const dashboardLink = screen.getByText('Dashboard').closest('a');
     expect(dashboardLink).toHaveAttribute('href', ROUTES.APP.DASHBOARD);
@@ -75,13 +134,10 @@ describe('PrivateLayout', () => {
 
   it('devrait appeler logout et navigate au clic sur Déconnexion', () => {
     const logout = vi.fn();
-    useAuthStore.setState({ logout });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    mockAuthStoreState.logout = logout;
 
-    render(
-      <MemoryRouter>
-        <PrivateLayout />
-      </MemoryRouter>
-    );
+    render(<PrivateLayout />, { wrapper });
 
     const logoutButton = screen.getByText('Déconnexion');
     logoutButton.click();

--- a/src/app/layouts/PrivateLayout.tsx
+++ b/src/app/layouts/PrivateLayout.tsx
@@ -2,6 +2,9 @@ import { Outlet, Link, useLocation, useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { ROUTES } from '@/shared/config/routes';
 import { useAuthStore } from '@/stores/authStore';
+import { UpgradeButton } from '@/widgets/UpgradeButton/UpgradeButton';
+import { PortalButton } from '@/widgets/PortalButton/PortalButton';
+import { PLANS } from '@/shared/config/plans';
 
 /**
  * Layout pour les routes privées (/app/*)
@@ -50,7 +53,16 @@ export function PrivateLayout(): JSX.Element {
           >
             Dashboard
           </Link>
-          <div style={{ marginLeft: 'auto' }}>
+          <div
+            style={{
+              marginLeft: 'auto',
+              display: 'flex',
+              gap: '0.5rem',
+              alignItems: 'center',
+            }}
+          >
+            <PortalButton />
+            <UpgradeButton plan={PLANS.PLUS} />
             <button
               type="button"
               onClick={handleLogout}

--- a/src/features/billing/hooks/useCheckout.test.tsx
+++ b/src/features/billing/hooks/useCheckout.test.tsx
@@ -1,0 +1,281 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useCheckout } from './useCheckout';
+import { billingService } from '@/shared/api/billing.service';
+import { ApiError, NetworkError } from '@/shared/api/errors';
+import { PLANS } from '@/shared/config/plans';
+import { toast } from '@/app/AppProviders';
+import React from 'react';
+
+// Mock billingService
+vi.mock('@/shared/api/billing.service', () => ({
+  billingService: {
+    createCheckoutSession: vi.fn(),
+  },
+}));
+
+// Mock toast
+vi.mock('@/app/AppProviders', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+// Mock window.location.assign
+const mockAssign = vi.fn();
+Object.defineProperty(window, 'location', {
+  value: {
+    assign: mockAssign,
+  },
+  writable: true,
+});
+
+describe('useCheckout', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+        mutations: {
+          retry: false,
+        },
+      },
+    });
+    vi.clearAllMocks();
+    mockAssign.mockClear();
+  });
+
+  const wrapper = ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }): JSX.Element => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  it('devrait appeler createCheckoutSession et rediriger avec window.location.assign', async () => {
+    const checkoutUrl = 'https://checkout.stripe.com/pay/cs_test_123';
+
+    (
+      billingService.createCheckoutSession as ReturnType<typeof vi.fn>
+    ).mockResolvedValue(checkoutUrl);
+
+    const { result } = renderHook(() => useCheckout(), { wrapper });
+
+    await result.current.startCheckout(PLANS.PLUS);
+
+    await waitFor(() => {
+      expect(mockAssign).toHaveBeenCalledWith(checkoutUrl);
+    });
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(billingService.createCheckoutSession).toHaveBeenCalledWith(
+      PLANS.PLUS,
+      expect.any(String)
+    );
+  });
+
+  it('devrait générer une Idempotency-Key différente à chaque appel', async () => {
+    const checkoutUrl = 'https://checkout.stripe.com/pay/cs_test_123';
+
+    const mockCreateCheckoutSession = vi.mocked(
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      billingService.createCheckoutSession
+    );
+    mockCreateCheckoutSession.mockResolvedValue(checkoutUrl);
+
+    const { result } = renderHook(() => useCheckout(), { wrapper });
+
+    // Premier appel
+    await result.current.startCheckout(PLANS.PLUS);
+
+    const firstCall = mockCreateCheckoutSession.mock.calls[0];
+
+    const firstKey = firstCall[1];
+
+    // Deuxième appel
+    mockCreateCheckoutSession.mockClear();
+    await result.current.startCheckout(PLANS.PRO);
+
+    const secondCall = mockCreateCheckoutSession.mock.calls[0];
+
+    const secondKey = secondCall[1];
+
+    // Les clés doivent être différentes (UUID v4)
+    expect(firstKey).toBeDefined();
+    expect(secondKey).toBeDefined();
+    expect(firstKey).not.toBe(secondKey);
+  });
+
+  it('devrait bloquer les appels supplémentaires si isPending (double-clic)', async () => {
+    let resolvePromise: (value: string) => void;
+    const checkoutUrl = 'https://checkout.stripe.com/pay/cs_test_123';
+
+    const mockCreateCheckoutSession = vi.mocked(
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      billingService.createCheckoutSession
+    );
+    mockCreateCheckoutSession.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolvePromise = resolve;
+        })
+    );
+
+    const { result } = renderHook(() => useCheckout(), { wrapper });
+
+    // Premier appel (en cours)
+    void result.current.startCheckout(PLANS.PLUS);
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(true);
+    });
+
+    // Deuxième appel (doit être ignoré)
+    await result.current.startCheckout(PLANS.PLUS);
+
+    // Vérifier qu'un seul appel a été fait
+    expect(mockCreateCheckoutSession).toHaveBeenCalledTimes(1);
+
+    // Résoudre le premier appel
+    resolvePromise!(checkoutUrl);
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false);
+    });
+  });
+
+  it('devrait afficher toast et ne pas rediriger sur NetworkError', async () => {
+    const networkError = new NetworkError('timeout', 'Request timeout');
+
+    (
+      billingService.createCheckoutSession as ReturnType<typeof vi.fn>
+    ).mockRejectedValue(networkError);
+
+    const { result } = renderHook(() => useCheckout(), { wrapper });
+
+    await expect(result.current.startCheckout(PLANS.PLUS)).rejects.toThrow();
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        'Service Billing indisponible, réessayez.'
+      );
+    });
+
+    // Pas de redirection
+    expect(mockAssign).not.toHaveBeenCalled();
+  });
+
+  it('devrait ne pas rediriger sur 401 (laisse wrapper gérer)', async () => {
+    const apiError = new ApiError('Unauthorized', 401);
+
+    (
+      billingService.createCheckoutSession as ReturnType<typeof vi.fn>
+    ).mockRejectedValue(apiError);
+
+    const { result } = renderHook(() => useCheckout(), { wrapper });
+
+    await expect(result.current.startCheckout(PLANS.PLUS)).rejects.toThrow();
+
+    // Pas de toast pour 401 (géré par wrapper)
+    expect(toast.error).not.toHaveBeenCalled();
+
+    // Pas de redirection
+    expect(mockAssign).not.toHaveBeenCalled();
+  });
+
+  it('devrait afficher toast pour 409/400 "déjà abonné"', async () => {
+    const apiError = new ApiError(
+      'Already subscribed',
+      409,
+      undefined,
+      undefined,
+      {
+        message: 'Vous avez déjà un abonnement actif',
+      }
+    );
+
+    (
+      billingService.createCheckoutSession as ReturnType<typeof vi.fn>
+    ).mockRejectedValue(apiError);
+
+    const { result } = renderHook(() => useCheckout(), { wrapper });
+
+    await expect(result.current.startCheckout(PLANS.PLUS)).rejects.toThrow();
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "Vous avez déjà un abonnement actif. Utilisez le bouton 'Gérer mon abonnement'."
+      );
+    });
+  });
+
+  it('devrait afficher toast pour autres erreurs API (sauf 401)', async () => {
+    const apiError = new ApiError('Forbidden', 403);
+
+    (
+      billingService.createCheckoutSession as ReturnType<typeof vi.fn>
+    ).mockRejectedValue(apiError);
+
+    const { result } = renderHook(() => useCheckout(), { wrapper });
+
+    await expect(result.current.startCheckout(PLANS.PLUS)).rejects.toThrow();
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Forbidden');
+    });
+  });
+
+  it('devrait retourner isPending: true pendant la mutation', async () => {
+    let resolvePromise: (value: string) => void;
+    const checkoutUrl = 'https://checkout.stripe.com/pay/cs_test_123';
+
+    (
+      billingService.createCheckoutSession as ReturnType<typeof vi.fn>
+    ).mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolvePromise = resolve;
+        })
+    );
+
+    const { result } = renderHook(() => useCheckout(), { wrapper });
+
+    // Démarrer la mutation
+    void result.current.startCheckout(PLANS.PLUS);
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(true);
+    });
+
+    // Résoudre
+    resolvePromise!(checkoutUrl);
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false);
+    });
+  });
+
+  it('devrait retourner error après échec', async () => {
+    const apiError = new ApiError('Bad Request', 400);
+
+    (
+      billingService.createCheckoutSession as ReturnType<typeof vi.fn>
+    ).mockRejectedValue(apiError);
+
+    const { result } = renderHook(() => useCheckout(), { wrapper });
+
+    await expect(result.current.startCheckout(PLANS.PLUS)).rejects.toThrow();
+
+    await waitFor(() => {
+      expect(result.current.error).toBe(apiError);
+    });
+  });
+});

--- a/src/features/billing/hooks/useCheckout.ts
+++ b/src/features/billing/hooks/useCheckout.ts
@@ -1,0 +1,109 @@
+import { useMutation } from '@tanstack/react-query';
+import { v4 as uuidv4 } from 'uuid';
+import { billingService } from '@/shared/api/billing.service';
+import { assertValidPlan, type BillingPlan } from '@/shared/config/plans';
+import { ApiError, NetworkError } from '@/shared/api/errors';
+import { toast } from '@/app/AppProviders';
+
+/**
+ * Interface du résultat du hook useCheckout
+ */
+export interface UseCheckoutResult {
+  /** Fonction pour démarrer le checkout */
+  startCheckout: (plan: BillingPlan) => Promise<void>;
+  /** Indique si une mutation est en cours */
+  isPending: boolean;
+  /** Erreur de la dernière mutation */
+  error: Error | null;
+}
+
+/**
+ * Hook React Query pour créer une session checkout Stripe
+ * Protection double-clic intégrée (bloque si isPending)
+ * Gestion d'erreurs réaliste (401, 409/400, NetworkError)
+ */
+export function useCheckout(): UseCheckoutResult {
+  const { mutateAsync, isPending, error } = useMutation<
+    string,
+    Error,
+    { plan: BillingPlan; idemKey: string }
+  >({
+    mutationFn: async ({ plan, idemKey }) => {
+      return await billingService.createCheckoutSession(plan, idemKey);
+    },
+    onSuccess: (checkoutUrl) => {
+      // Redirection via window.location.assign (meilleur pour l'historique)
+      window.location.assign(checkoutUrl);
+    },
+    onError: (err) => {
+      // Gestion erreurs réaliste
+      if (err instanceof ApiError) {
+        // 401 → laisse le wrapper déclencher l'unauthorized (redir login via callback global)
+        // Pas de traitement spécial ici
+
+        // 409/400 "déjà abonné" → propose le Portal
+        if (
+          err.status === 409 ||
+          (err.status === 400 &&
+            typeof err.details === 'object' &&
+            err.details !== null &&
+            'message' in err.details &&
+            typeof (err.details as { message?: string }).message === 'string' &&
+            ((err.details as { message: string }).message.includes(
+              'abonnement'
+            ) ||
+              (err.details as { message: string }).message.includes('déjà')))
+        ) {
+          toast.error(
+            "Vous avez déjà un abonnement actif. Utilisez le bouton 'Gérer mon abonnement'."
+          );
+        } else if (err.status !== 401) {
+          // Autres erreurs API (sauf 401 déjà gérée)
+          const message =
+            err.message || 'Une erreur est survenue lors du checkout.';
+          toast.error(message);
+        }
+      } else if (err instanceof NetworkError) {
+        // NetworkError/timeout → toast clair
+        const message =
+          err.reason === 'timeout' || err.reason === 'offline'
+            ? 'Service Billing indisponible, réessayez.'
+            : 'Erreur réseau lors du checkout.';
+        toast.error(message);
+      } else {
+        // Erreur inconnue
+        toast.error('Une erreur inattendue est survenue.');
+      }
+
+      // Journalisation légère : log request_id si présent (utile en support)
+      if (err instanceof ApiError && err.requestId !== undefined) {
+        console.error('[Checkout] request_id:', err.requestId);
+      }
+    },
+  });
+
+  /**
+   * Fonction pour démarrer le checkout avec protection double-clic
+   */
+  const startCheckout = async (plan: BillingPlan): Promise<void> => {
+    // Protection double-clic : bloquer un second appel tant que isPending est true
+    if (isPending) {
+      return;
+    }
+
+    // Validation plan en dev
+    assertValidPlan(plan);
+
+    // Génération Idempotency-Key au clic (UUID v4)
+    const idemKey = uuidv4();
+
+    // Les erreurs sont déjà gérées dans onError
+    await mutateAsync({ plan, idemKey });
+  };
+
+  return {
+    startCheckout,
+    isPending,
+    error: error ?? null,
+  };
+}

--- a/src/features/billing/hooks/usePortal.test.tsx
+++ b/src/features/billing/hooks/usePortal.test.tsx
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { usePortal } from './usePortal';
+import { billingService } from '@/shared/api/billing.service';
+import { ApiError, NetworkError } from '@/shared/api/errors';
+import { toast } from '@/app/AppProviders';
+import React from 'react';
+
+// Mock billingService
+vi.mock('@/shared/api/billing.service', () => ({
+  billingService: {
+    createPortalSession: vi.fn(),
+  },
+}));
+
+// Mock toast
+vi.mock('@/app/AppProviders', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+// Mock window.location.assign
+const mockAssign = vi.fn();
+Object.defineProperty(window, 'location', {
+  value: {
+    assign: mockAssign,
+  },
+  writable: true,
+});
+
+describe('usePortal', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+        mutations: {
+          retry: false,
+        },
+      },
+    });
+    vi.clearAllMocks();
+    mockAssign.mockClear();
+  });
+
+  const wrapper = ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }): JSX.Element => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  it('devrait appeler createPortalSession et rediriger avec window.location.assign', async () => {
+    const portalUrl = 'https://billing.stripe.com/p/session_123';
+
+    const mockCreatePortalSession = vi.mocked(
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      billingService.createPortalSession
+    );
+    mockCreatePortalSession.mockResolvedValue(portalUrl);
+
+    const { result } = renderHook(() => usePortal(), { wrapper });
+
+    await result.current.openPortal();
+
+    await waitFor(() => {
+      expect(mockAssign).toHaveBeenCalledWith(portalUrl);
+    });
+
+    expect(mockCreatePortalSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('devrait bloquer les appels supplémentaires si isPending (double-clic)', async () => {
+    let resolvePromise: (value: string) => void;
+    const portalUrl = 'https://billing.stripe.com/p/session_123';
+
+    const mockCreatePortalSession = vi.mocked(
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      billingService.createPortalSession
+    );
+    mockCreatePortalSession.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolvePromise = resolve;
+        })
+    );
+
+    const { result } = renderHook(() => usePortal(), { wrapper });
+
+    // Premier appel (en cours)
+    void result.current.openPortal();
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(true);
+    });
+
+    // Deuxième appel (doit être ignoré)
+    await result.current.openPortal();
+
+    // Vérifier qu'un seul appel a été fait
+    expect(mockCreatePortalSession).toHaveBeenCalledTimes(1);
+
+    // Résoudre le premier appel
+    resolvePromise!(portalUrl);
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false);
+    });
+  });
+
+  it('devrait afficher toast et ne pas rediriger sur NetworkError', async () => {
+    const networkError = new NetworkError('offline', 'Network error');
+
+    (
+      billingService.createPortalSession as ReturnType<typeof vi.fn>
+    ).mockRejectedValue(networkError);
+
+    const { result } = renderHook(() => usePortal(), { wrapper });
+
+    await expect(result.current.openPortal()).rejects.toThrow();
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        'Service Billing indisponible, réessayez.'
+      );
+    });
+
+    // Pas de redirection
+    expect(mockAssign).not.toHaveBeenCalled();
+  });
+
+  it('devrait ne pas rediriger sur 401 (laisse wrapper gérer)', async () => {
+    const apiError = new ApiError('Unauthorized', 401);
+
+    (
+      billingService.createPortalSession as ReturnType<typeof vi.fn>
+    ).mockRejectedValue(apiError);
+
+    const { result } = renderHook(() => usePortal(), { wrapper });
+
+    await expect(result.current.openPortal()).rejects.toThrow();
+
+    // Pas de toast pour 401 (géré par wrapper)
+    expect(toast.error).not.toHaveBeenCalled();
+
+    // Pas de redirection
+    expect(mockAssign).not.toHaveBeenCalled();
+  });
+
+  it('devrait afficher toast pour autres erreurs API (sauf 401)', async () => {
+    const apiError = new ApiError('Forbidden', 403);
+
+    (
+      billingService.createPortalSession as ReturnType<typeof vi.fn>
+    ).mockRejectedValue(apiError);
+
+    const { result } = renderHook(() => usePortal(), { wrapper });
+
+    await expect(result.current.openPortal()).rejects.toThrow();
+
+    await waitFor(() => {
+      // Le code utilise err.message si disponible, sinon le message par défaut
+      expect(toast.error).toHaveBeenCalledWith('Forbidden');
+    });
+  });
+
+  it('devrait retourner isPending: true pendant la mutation', async () => {
+    let resolvePromise: (value: string) => void;
+    const portalUrl = 'https://billing.stripe.com/p/session_123';
+
+    (
+      billingService.createPortalSession as ReturnType<typeof vi.fn>
+    ).mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolvePromise = resolve;
+        })
+    );
+
+    const { result } = renderHook(() => usePortal(), { wrapper });
+
+    // Démarrer la mutation
+    void result.current.openPortal();
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(true);
+    });
+
+    // Résoudre
+    resolvePromise!(portalUrl);
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false);
+    });
+  });
+
+  it('devrait retourner error après échec', async () => {
+    const apiError = new ApiError('Bad Request', 400);
+
+    (
+      billingService.createPortalSession as ReturnType<typeof vi.fn>
+    ).mockRejectedValue(apiError);
+
+    const { result } = renderHook(() => usePortal(), { wrapper });
+
+    await expect(result.current.openPortal()).rejects.toThrow();
+
+    await waitFor(() => {
+      expect(result.current.error).toBe(apiError);
+    });
+  });
+});

--- a/src/features/billing/hooks/usePortal.ts
+++ b/src/features/billing/hooks/usePortal.ts
@@ -1,0 +1,80 @@
+import { useMutation } from '@tanstack/react-query';
+import { billingService } from '@/shared/api/billing.service';
+import { ApiError, NetworkError } from '@/shared/api/errors';
+import { toast } from '@/app/AppProviders';
+
+/**
+ * Interface du résultat du hook usePortal
+ */
+export interface UsePortalResult {
+  /** Fonction pour ouvrir le portal Stripe */
+  openPortal: () => Promise<void>;
+  /** Indique si une mutation est en cours */
+  isPending: boolean;
+  /** Erreur de la dernière mutation */
+  error: Error | null;
+}
+
+/**
+ * Hook React Query pour créer une session portal Stripe
+ * Protection double-clic intégrée (bloque si isPending)
+ * Gestion d'erreurs réaliste (401, NetworkError)
+ */
+export function usePortal(): UsePortalResult {
+  const { mutateAsync, isPending, error } = useMutation<string, Error>({
+    mutationFn: async () => {
+      return await billingService.createPortalSession();
+    },
+    onSuccess: (portalUrl) => {
+      // Redirection via window.location.assign (meilleur pour l'historique)
+      window.location.assign(portalUrl);
+    },
+    onError: (err) => {
+      // Gestion erreurs réaliste
+      if (err instanceof ApiError) {
+        // 401 → laisse le wrapper déclencher l'unauthorized (redir login via callback global)
+        // Pas de traitement spécial ici
+        if (err.status !== 401) {
+          // Autres erreurs API (sauf 401 déjà gérée)
+          const message =
+            err.message || "Une erreur est survenue lors de l'accès au portal.";
+          toast.error(message);
+        }
+      } else if (err instanceof NetworkError) {
+        // NetworkError/timeout → toast clair
+        const message =
+          err.reason === 'timeout' || err.reason === 'offline'
+            ? 'Service Billing indisponible, réessayez.'
+            : "Erreur réseau lors de l'accès au portal.";
+        toast.error(message);
+      } else {
+        // Erreur inconnue
+        toast.error('Une erreur inattendue est survenue.');
+      }
+
+      // Journalisation légère : log request_id si présent (utile en support)
+      if (err instanceof ApiError && err.requestId !== undefined) {
+        console.error('[Portal] request_id:', err.requestId);
+      }
+    },
+  });
+
+  /**
+   * Fonction pour ouvrir le portal avec protection double-clic
+   */
+  const openPortal = async (): Promise<void> => {
+    // Protection double-clic : bloquer un second appel tant que isPending est true
+    if (isPending) {
+      return;
+    }
+
+    // Les erreurs sont déjà gérées dans onError
+    await mutateAsync();
+  };
+
+  return {
+    openPortal,
+    isPending,
+    error: error ?? null,
+  };
+}

--- a/src/pages/app/dashboard/index.tsx
+++ b/src/pages/app/dashboard/index.tsx
@@ -1,4 +1,9 @@
+import { useEffect } from 'react';
 import { useTitle } from '@/shared/hooks/useTitle';
+import { useQueryClient } from '@tanstack/react-query';
+import { UpgradeButton } from '@/widgets/UpgradeButton/UpgradeButton';
+import { PortalButton } from '@/widgets/PortalButton/PortalButton';
+import { PLANS } from '@/shared/config/plans';
 
 /**
  * Page Dashboard (privée)
@@ -6,11 +11,61 @@ import { useTitle } from '@/shared/hooks/useTitle';
  */
 export function DashboardPage(): JSX.Element {
   useTitle('Horoscope - Dashboard');
+  const queryClient = useQueryClient();
+
+  // Post-checkout : revalidation des queries paywall au retour de Stripe
+  // Ne pas déduire l'état du plan localement : laisser les webhooks faire foi
+  useEffect(() => {
+    void queryClient.invalidateQueries({ queryKey: ['paywall'] });
+  }, [queryClient]);
 
   return (
     <div>
       <h1>Dashboard</h1>
       <p>Bienvenue sur votre tableau de bord</p>
+
+      {/* Section "Mon offre" */}
+      <div
+        style={{
+          marginTop: '2rem',
+          padding: '1.5rem',
+          backgroundColor: '#f9f9f9',
+          borderRadius: '8px',
+          border: '1px solid #e0e0e0',
+        }}
+      >
+        <h2 style={{ marginTop: 0, marginBottom: '1rem' }}>Mon offre</h2>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '1rem',
+          }}
+        >
+          <div>
+            <p style={{ marginBottom: '0.5rem' }}>
+              Passez à un plan supérieur pour accéder à plus de fonctionnalités
+            </p>
+            <div
+              style={{
+                display: 'flex',
+                gap: '1rem',
+                flexWrap: 'wrap',
+              }}
+            >
+              <UpgradeButton plan={PLANS.PLUS} />
+              <UpgradeButton plan={PLANS.PRO} />
+            </div>
+          </div>
+          <div style={{ borderTop: '1px solid #e0e0e0', paddingTop: '1rem' }}>
+            <p style={{ marginBottom: '0.5rem' }}>
+              Gérer votre abonnement existant
+            </p>
+            <PortalButton />
+          </div>
+        </div>
+      </div>
+
       <div
         style={{
           marginTop: '2rem',

--- a/src/shared/api/billing.service.test.ts
+++ b/src/shared/api/billing.service.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { billingService } from './billing.service';
+import { http } from './client';
+import { PLANS } from '@/shared/config/plans';
+import { ApiError } from './errors';
+import { NetworkError } from './errors';
+
+// Mock le client HTTP
+vi.mock('./client', () => ({
+  http: {
+    post: vi.fn(),
+  },
+}));
+
+// Mock eventBus
+vi.mock('./eventBus', () => ({
+  eventBus: {
+    emit: vi.fn(),
+  },
+}));
+
+describe('billingService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('createCheckoutSession', () => {
+    const idemKey = 'test-idempotency-key-123';
+
+    it('devrait retourner checkout_url valide avec réponse valide', async () => {
+      const mockResponse = {
+        checkout_url: 'https://checkout.stripe.com/pay/cs_test_123',
+      };
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const mockHttpPost = vi.mocked(http.post);
+      (mockHttpPost as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockResponse
+      );
+
+      const result = await billingService.createCheckoutSession(
+        PLANS.PLUS,
+        idemKey
+      );
+
+      expect(result).toBe('https://checkout.stripe.com/pay/cs_test_123');
+      expect(mockHttpPost).toHaveBeenCalledWith(
+        '/v1/billing/checkout',
+        { plan: 'plus' },
+        {
+          idempotency: true,
+          headers: {
+            'Idempotency-Key': idemKey,
+          },
+        }
+      );
+    });
+
+    it('devrait appeler avec body exact { plan }', async () => {
+      const mockResponse = {
+        checkout_url: 'https://checkout.stripe.com/pay/cs_test_123',
+      };
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const mockHttpPost = vi.mocked(http.post);
+      (mockHttpPost as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockResponse
+      );
+
+      await billingService.createCheckoutSession(PLANS.PRO, idemKey);
+
+      expect(mockHttpPost).toHaveBeenCalledWith(
+        '/v1/billing/checkout',
+        { plan: 'pro' },
+
+        expect.objectContaining({
+          idempotency: true,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          headers: expect.objectContaining({
+            'Idempotency-Key': idemKey,
+          }),
+        })
+      );
+    });
+
+    it('devrait utiliser la clé Idempotency-Key passée dans les headers', async () => {
+      const customIdemKey = 'custom-key-456';
+      const mockResponse = {
+        checkout_url: 'https://checkout.stripe.com/pay/cs_test_123',
+      };
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const mockHttpPost = vi.mocked(http.post);
+      (mockHttpPost as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockResponse
+      );
+
+      await billingService.createCheckoutSession(PLANS.PLUS, customIdemKey);
+
+      expect(mockHttpPost).toHaveBeenCalledWith(
+        '/v1/billing/checkout',
+        { plan: 'plus' },
+
+        expect.objectContaining({
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          headers: expect.objectContaining({
+            'Idempotency-Key': customIdemKey,
+          }),
+        })
+      );
+    });
+
+    it('devrait échouer si checkout_url manquant', async () => {
+      const mockResponse = {
+        // checkout_url manquant
+      };
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const mockHttpPost = vi.mocked(http.post);
+      (mockHttpPost as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockResponse
+      );
+
+      await expect(
+        billingService.createCheckoutSession(PLANS.PLUS, idemKey)
+      ).rejects.toThrow();
+    });
+
+    it('devrait échouer si checkout_url invalide (pas une URL)', async () => {
+      const mockResponse = {
+        checkout_url: 'not-a-valid-url',
+      };
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const mockHttpPost = vi.mocked(http.post);
+      (mockHttpPost as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockResponse
+      );
+
+      await expect(
+        billingService.createCheckoutSession(PLANS.PLUS, idemKey)
+      ).rejects.toThrow();
+    });
+
+    it('devrait échouer si JSON invalide → ZodError (fail-fast)', async () => {
+      const mockResponse = {
+        // Réponse invalide
+        wrong_field: 'value',
+      };
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const mockHttpPost = vi.mocked(http.post);
+      (mockHttpPost as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockResponse
+      );
+
+      await expect(
+        billingService.createCheckoutSession(PLANS.PLUS, idemKey)
+      ).rejects.toThrow('Invalid checkout response');
+    });
+
+    it('devrait propager ApiError 401 et déclencher événement unauthorized', async () => {
+      const apiError = new ApiError('Unauthorized', 401);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const mockHttpPost = vi.mocked(http.post);
+      (mockHttpPost as ReturnType<typeof vi.fn>).mockRejectedValue(apiError);
+
+      await expect(
+        billingService.createCheckoutSession(PLANS.PLUS, idemKey)
+      ).rejects.toThrow(ApiError);
+
+      // L'événement unauthorized est émis par le wrapper client.ts
+      // On vérifie que l'erreur est propagée correctement
+      expect(mockHttpPost).toHaveBeenCalled();
+    });
+
+    it('devrait propager NetworkError', async () => {
+      const networkError = new NetworkError('timeout', 'Request timeout');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const mockHttpPost = vi.mocked(http.post);
+      (mockHttpPost as ReturnType<typeof vi.fn>).mockRejectedValue(
+        networkError
+      );
+
+      await expect(
+        billingService.createCheckoutSession(PLANS.PLUS, idemKey)
+      ).rejects.toThrow(NetworkError);
+    });
+  });
+
+  describe('createPortalSession', () => {
+    it('devrait retourner portal_url valide avec réponse valide', async () => {
+      const mockResponse = {
+        portal_url: 'https://billing.stripe.com/p/session_123',
+      };
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const mockHttpPost = vi.mocked(http.post);
+      (mockHttpPost as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockResponse
+      );
+
+      const result = await billingService.createPortalSession();
+
+      expect(result).toBe('https://billing.stripe.com/p/session_123');
+      expect(mockHttpPost).toHaveBeenCalledWith('/v1/billing/portal', {});
+    });
+
+    it('devrait appeler POST sans body et sans idempotency', async () => {
+      const mockResponse = {
+        portal_url: 'https://billing.stripe.com/p/session_123',
+      };
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const mockHttpPost = vi.mocked(http.post);
+      (mockHttpPost as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockResponse
+      );
+
+      await billingService.createPortalSession();
+
+      expect(mockHttpPost).toHaveBeenCalledWith('/v1/billing/portal', {});
+      // Vérifier qu'on n'utilise pas idempotency (pas de 3e paramètre avec idempotency: true)
+      const calls = mockHttpPost.mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall).toHaveLength(2); // Seulement endpoint et body
+    });
+
+    it('devrait échouer si portal_url manquant', async () => {
+      const mockResponse = {
+        // portal_url manquant
+      };
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const mockHttpPost = vi.mocked(http.post);
+      (mockHttpPost as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockResponse
+      );
+
+      await expect(billingService.createPortalSession()).rejects.toThrow();
+    });
+
+    it('devrait échouer si portal_url invalide (pas une URL)', async () => {
+      const mockResponse = {
+        portal_url: 'not-a-valid-url',
+      };
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const mockHttpPost = vi.mocked(http.post);
+      (mockHttpPost as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockResponse
+      );
+
+      await expect(billingService.createPortalSession()).rejects.toThrow();
+    });
+
+    it('devrait échouer si JSON invalide → ZodError (fail-fast)', async () => {
+      const mockResponse = {
+        // Réponse invalide
+        wrong_field: 'value',
+      };
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const mockHttpPost = vi.mocked(http.post);
+      (mockHttpPost as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockResponse
+      );
+
+      await expect(billingService.createPortalSession()).rejects.toThrow(
+        'Invalid portal response'
+      );
+    });
+
+    it('devrait propager ApiError', async () => {
+      const apiError = new ApiError('Forbidden', 403);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const mockHttpPost = vi.mocked(http.post);
+      (mockHttpPost as ReturnType<typeof vi.fn>).mockRejectedValue(apiError);
+
+      await expect(billingService.createPortalSession()).rejects.toThrow(
+        ApiError
+      );
+    });
+
+    it('devrait propager NetworkError', async () => {
+      const networkError = new NetworkError('offline', 'Network error');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const mockHttpPost = vi.mocked(http.post);
+      (mockHttpPost as ReturnType<typeof vi.fn>).mockRejectedValue(
+        networkError
+      );
+
+      await expect(billingService.createPortalSession()).rejects.toThrow(
+        NetworkError
+      );
+    });
+  });
+});

--- a/src/shared/api/billing.service.ts
+++ b/src/shared/api/billing.service.ts
@@ -1,0 +1,95 @@
+import { z } from 'zod';
+import { http } from './client';
+import { assertValidPlan, type BillingPlan } from '@/shared/config/plans';
+
+/**
+ * Schémas Zod stricts pour les réponses billing
+ */
+
+/**
+ * Schéma pour la réponse de création de session checkout
+ */
+export const CheckoutSessionSchema = z.object({
+  checkout_url: z.string().url(),
+});
+
+/**
+ * Schéma pour la réponse de création de session portal
+ */
+export const PortalSessionSchema = z.object({
+  portal_url: z.string().url(),
+});
+
+/**
+ * Types inférés depuis les schémas Zod
+ */
+export type CheckoutSessionResponse = z.infer<typeof CheckoutSessionSchema>;
+export type PortalSessionResponse = z.infer<typeof PortalSessionSchema>;
+
+/**
+ * Service pour gérer les sessions billing (checkout & portal)
+ */
+export const billingService = {
+  /**
+   * Crée une session checkout Stripe pour un plan donné
+   * @param plan Plan de facturation (plus | pro)
+   * @param idemKey Clé d'idempotence (UUID v4) générée au clic
+   * @returns URL de checkout Stripe
+   * @throws ApiError si erreur API (401, 409, etc.)
+   * @throws NetworkError si erreur réseau
+   * @throws Error si réponse invalide (ZodError)
+   */
+  async createCheckoutSession(
+    plan: BillingPlan,
+    idemKey: string
+  ): Promise<string> {
+    // Vérifier le plan en dev
+    assertValidPlan(plan);
+
+    try {
+      const response = await http.post<unknown>(
+        '/v1/billing/checkout',
+        { plan },
+        {
+          idempotency: true,
+          headers: {
+            'Idempotency-Key': idemKey,
+          },
+        }
+      );
+
+      // Validation Zod stricte (fail-fast)
+      const validated = CheckoutSessionSchema.parse(response);
+      return validated.checkout_url;
+    } catch (error) {
+      // Si c'est une ZodError, enrichir le message
+      if (error instanceof z.ZodError) {
+        throw new Error(`Invalid checkout response: ${error.message}`);
+      }
+      throw error;
+    }
+  },
+
+  /**
+   * Crée une session portal Stripe pour gérer l'abonnement
+   * @returns URL du portal Stripe
+   * @throws ApiError si erreur API (401, etc.)
+   * @throws NetworkError si erreur réseau
+   * @throws Error si réponse invalide (ZodError)
+   */
+  async createPortalSession(): Promise<string> {
+    try {
+      const response = await http.post<unknown>('/v1/billing/portal', {});
+
+      // Validation Zod stricte (fail-fast)
+      const validated = PortalSessionSchema.parse(response);
+      return validated.portal_url;
+    } catch (error) {
+      // Si c'est une ZodError, enrichir le message
+      if (error instanceof z.ZodError) {
+        throw new Error(`Invalid portal response: ${error.message}`);
+      }
+      throw error;
+    }
+  },
+};

--- a/src/shared/config/plans.test.ts
+++ b/src/shared/config/plans.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { assertValidPlan, PLANS } from './plans';
+
+describe('plans', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('assertValidPlan', () => {
+    it('devrait accepter plan "plus"', () => {
+      expect(() => assertValidPlan('plus')).not.toThrow();
+    });
+
+    it('devrait accepter plan "pro"', () => {
+      expect(() => assertValidPlan('pro')).not.toThrow();
+    });
+
+    it('devrait accepter PLANS.PLUS', () => {
+      expect(() => assertValidPlan(PLANS.PLUS)).not.toThrow();
+    });
+
+    it('devrait accepter PLANS.PRO', () => {
+      expect(() => assertValidPlan(PLANS.PRO)).not.toThrow();
+    });
+
+    it('devrait lever une erreur en dev si plan inconnu', () => {
+      // Note: Ce test fonctionne uniquement en dev (import.meta.env.DEV)
+      // En prod, assertValidPlan est no-op silencieux
+      if (import.meta.env.DEV) {
+        expect(() => assertValidPlan('unknown')).toThrow('Unknown plan');
+        expect(() => assertValidPlan('invalid')).toThrow('Unknown plan');
+      }
+    });
+
+    it("devrait être no-op silencieux en prod (ne pas lever d'erreur)", () => {
+      // Note: Ce test vérifie le comportement en prod
+      // Si on est en dev, on vérifie juste que ça ne plante pas sur plan valide
+      expect(() => assertValidPlan('plus')).not.toThrow();
+      expect(() => assertValidPlan('pro')).not.toThrow();
+    });
+  });
+
+  describe('PLANS', () => {
+    it('devrait avoir PLANS.PLUS égal à "plus"', () => {
+      expect(PLANS.PLUS).toBe('plus');
+    });
+
+    it('devrait avoir PLANS.PRO égal à "pro"', () => {
+      expect(PLANS.PRO).toBe('pro');
+    });
+  });
+});

--- a/src/shared/config/plans.ts
+++ b/src/shared/config/plans.ts
@@ -1,0 +1,37 @@
+/**
+ * Plans de facturation centralisés
+ * Évite les typos et facilite la maintenance
+ */
+
+/**
+ * Type strict pour les plans de facturation
+ */
+export type BillingPlan = 'plus' | 'pro';
+
+/**
+ * Constantes pour les plans de facturation
+ */
+export const PLANS = {
+  PLUS: 'plus',
+  PRO: 'pro',
+} as const;
+
+/**
+ * Labels UI pour les plans (séparés de la clé API)
+ */
+export const PLAN_LABELS: Record<BillingPlan, string> = {
+  plus: 'Plus',
+  pro: 'Pro',
+};
+
+/**
+ * Vérifie qu'un plan est valide (uniquement en dev)
+ * No-op silencieux en production
+ * @param p Plan à valider
+ * @throws Error en dev si plan inconnu
+ */
+export function assertValidPlan(p: string): asserts p is BillingPlan {
+  if (import.meta.env.DEV && p !== 'plus' && p !== 'pro') {
+    throw new Error(`Unknown plan: ${p}`);
+  }
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -20,7 +20,7 @@ interface ProcessLike {
     env?: Record<string, string | undefined>;
   };
 }
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+
 const processEnv: unknown =
   typeof (globalThis as ProcessLike).process !== 'undefined'
     ? (

--- a/src/widgets/PortalButton/PortalButton.test.tsx
+++ b/src/widgets/PortalButton/PortalButton.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { PortalButton } from './PortalButton';
+import { usePortal } from '@/features/billing/hooks/usePortal';
+import React from 'react';
+
+// Mock usePortal
+vi.mock('@/features/billing/hooks/usePortal', () => ({
+  usePortal: vi.fn(),
+}));
+
+// Mock useAuthStore
+const mockAuthStore = {
+  token: 'test-token',
+  getToken: vi.fn(() => 'test-token'),
+};
+
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: vi.fn(
+    (selector: (state: typeof mockAuthStore) => string | null) =>
+      selector(mockAuthStore)
+  ),
+}));
+
+describe('PortalButton', () => {
+  let queryClient: QueryClient;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockOpenPortal: ReturnType<typeof vi.fn<any, any>>;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+        mutations: {
+          retry: false,
+        },
+      },
+    });
+    vi.clearAllMocks();
+
+    mockOpenPortal = vi.fn().mockResolvedValue(undefined);
+
+    const mockUsePortal = usePortal as unknown as ReturnType<typeof vi.fn>;
+    mockUsePortal.mockReturnValue({
+      openPortal: mockOpenPortal,
+      isPending: false,
+      error: null,
+    });
+
+    // Par défaut, token présent (utilisateur connecté)
+    mockAuthStore.token = 'test-token';
+    mockAuthStore.getToken = vi.fn(() => 'test-token');
+  });
+
+  const wrapper = ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }): JSX.Element => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  it('devrait afficher le label par défaut "Gérer mon abonnement"', () => {
+    render(<PortalButton />, { wrapper });
+
+    expect(screen.getByText('Gérer mon abonnement')).toBeInTheDocument();
+  });
+
+  it('devrait afficher le label personnalisé si fourni', () => {
+    render(<PortalButton label="Mon abonnement" />, { wrapper });
+
+    expect(screen.getByText('Mon abonnement')).toBeInTheDocument();
+  });
+
+  it('devrait appeler openPortal au clic si token présent', async () => {
+    render(<PortalButton />, { wrapper });
+
+    const button = screen.getByRole('button');
+    button.click();
+
+    await waitFor(() => {
+      expect(mockOpenPortal).toHaveBeenCalled();
+    });
+  });
+
+  it('devrait être désactivé si pas de JWT', () => {
+    mockAuthStore.token = null;
+    mockAuthStore.getToken = vi.fn(() => null);
+
+    render(<PortalButton />, { wrapper });
+
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute(
+      'title',
+      "Connecte-toi pour gérer l'abonnement"
+    );
+  });
+
+  it('devrait avoir title="Connecte-toi pour gérer l\'abonnement" si pas de JWT', () => {
+    mockAuthStore.token = null;
+    mockAuthStore.getToken = vi.fn(() => null);
+
+    render(<PortalButton />, { wrapper });
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute(
+      'title',
+      "Connecte-toi pour gérer l'abonnement"
+    );
+  });
+
+  it('devrait ne pas appeler openPortal si pas de JWT', async () => {
+    mockAuthStore.token = null;
+    mockAuthStore.getToken = vi.fn(() => null);
+
+    render(<PortalButton />, { wrapper });
+
+    const button = screen.getByRole('button');
+    button.click();
+
+    await waitFor(() => {
+      expect(mockOpenPortal).not.toHaveBeenCalled();
+    });
+  });
+
+  it('devrait afficher "Chargement…" et se désactiver pendant la mutation', () => {
+    (usePortal as ReturnType<typeof vi.fn>).mockReturnValue({
+      openPortal: mockOpenPortal,
+      isPending: true,
+      error: null,
+    });
+
+    render(<PortalButton />, { wrapper });
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveTextContent('Chargement…');
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('devrait avoir aria-busy={true} pendant la mutation', () => {
+    (usePortal as ReturnType<typeof vi.fn>).mockReturnValue({
+      openPortal: mockOpenPortal,
+      isPending: true,
+      error: null,
+    });
+
+    render(<PortalButton />, { wrapper });
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it("devrait ignorer le double-clic (pas d'appel supplémentaire si isPending)", async () => {
+    (usePortal as ReturnType<typeof vi.fn>).mockReturnValue({
+      openPortal: mockOpenPortal,
+      isPending: true,
+      error: null,
+    });
+
+    render(<PortalButton />, { wrapper });
+
+    const button = screen.getByRole('button');
+    button.click();
+    button.click(); // Second clic (doit être ignoré)
+
+    await waitFor(() => {
+      expect(mockOpenPortal).not.toHaveBeenCalled();
+    });
+  });
+
+  it('devrait supporter la variante primary', () => {
+    render(<PortalButton variant="primary" />, { wrapper });
+
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+  });
+});

--- a/src/widgets/PortalButton/PortalButton.tsx
+++ b/src/widgets/PortalButton/PortalButton.tsx
@@ -1,0 +1,82 @@
+import { usePortal } from '@/features/billing/hooks/usePortal';
+import { useAuthStore } from '@/stores/authStore';
+
+/**
+ * Props pour le composant PortalButton
+ */
+export interface PortalButtonProps {
+  /** Label personnalisé (défaut "Gérer mon abonnement") */
+  label?: string;
+  /** Variante du bouton */
+  variant?: 'primary' | 'secondary';
+}
+
+/**
+ * Composant pour accéder au portal Stripe (gestion abonnements)
+ * Utilise usePortal() pour créer session portal et rediriger
+ * Nécessite JWT (désactivé si pas de token)
+ * Gère l'état pending avec disabled et aria-busy
+ */
+export function PortalButton({
+  label = 'Gérer mon abonnement',
+  variant = 'secondary',
+}: PortalButtonProps = {}): JSX.Element {
+  const { openPortal, isPending } = usePortal();
+  const token = useAuthStore((state) => state.getToken());
+  const hasToken = token !== null && token !== '';
+
+  const displayLabel = isPending ? 'Chargement…' : label;
+
+  const handleClick = (): void => {
+    // Ignore les clics si pending ou pas de token
+    if (isPending || !hasToken) {
+      return;
+    }
+
+    // Ouvrir le portal
+    void openPortal();
+  };
+
+  const baseStyle: React.CSSProperties = {
+    padding: '0.5rem 1rem',
+    border: 'none',
+    borderRadius: '0.25rem',
+    cursor: isPending || !hasToken ? 'not-allowed' : 'pointer',
+    fontWeight: 500,
+    transition: 'opacity 0.2s',
+    opacity: isPending || !hasToken ? 0.7 : 1,
+  };
+
+  const variantStyles: Record<'primary' | 'secondary', React.CSSProperties> = {
+    primary: {
+      backgroundColor: '#f59e0b',
+      color: 'white',
+    },
+    secondary: {
+      backgroundColor: 'transparent',
+      color: '#f59e0b',
+      border: '1px solid #f59e0b',
+    },
+  };
+
+  const disabledTooltip = !hasToken
+    ? "Connecte-toi pour gérer l'abonnement"
+    : undefined;
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={isPending || !hasToken}
+      aria-busy={isPending}
+      aria-label={label}
+      title={disabledTooltip ?? label}
+      style={{
+        ...baseStyle,
+        ...variantStyles[variant],
+      }}
+    >
+      {displayLabel}
+    </button>
+  );
+}

--- a/src/widgets/UpgradeButton/UpgradeButton.test.tsx
+++ b/src/widgets/UpgradeButton/UpgradeButton.test.tsx
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { UpgradeButton } from './UpgradeButton';
+import { useCheckout } from '@/features/billing/hooks/useCheckout';
+import { PLANS } from '@/shared/config/plans';
+import React from 'react';
+
+// Mock useCheckout
+vi.mock('@/features/billing/hooks/useCheckout', () => ({
+  useCheckout: vi.fn(),
+}));
+
+describe('UpgradeButton', () => {
+  let queryClient: QueryClient;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockStartCheckout: ReturnType<typeof vi.fn<any, any>>;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+        mutations: {
+          retry: false,
+        },
+      },
+    });
+    vi.clearAllMocks();
+
+    mockStartCheckout = vi.fn().mockResolvedValue(undefined);
+
+    const mockUseCheckout = useCheckout as unknown as ReturnType<typeof vi.fn>;
+    mockUseCheckout.mockReturnValue({
+      startCheckout: mockStartCheckout,
+      isPending: false,
+      error: null,
+    });
+  });
+
+  const wrapper = ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }): JSX.Element => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  it('devrait afficher le label par défaut depuis PLAN_LABELS si non fourni', () => {
+    render(<UpgradeButton plan={PLANS.PLUS} />, { wrapper });
+
+    expect(screen.getByText(/Passer au plan Plus/i)).toBeInTheDocument();
+  });
+
+  it('devrait afficher le label personnalisé si fourni', () => {
+    render(<UpgradeButton plan={PLANS.PLUS} label="Plan Premium" />, {
+      wrapper,
+    });
+
+    expect(
+      screen.getByText(/Passer au plan Plan Premium/i)
+    ).toBeInTheDocument();
+  });
+
+  it('devrait appeler startCheckout avec le plan au clic', async () => {
+    render(<UpgradeButton plan={PLANS.PLUS} />, { wrapper });
+
+    const button = screen.getByRole('button');
+    button.click();
+
+    await waitFor(() => {
+      expect(mockStartCheckout).toHaveBeenCalledWith(PLANS.PLUS);
+    });
+  });
+
+  it('devrait afficher "Chargement…" et se désactiver pendant la mutation', () => {
+    (useCheckout as ReturnType<typeof vi.fn>).mockReturnValue({
+      startCheckout: mockStartCheckout,
+      isPending: true,
+      error: null,
+    });
+
+    render(<UpgradeButton plan={PLANS.PLUS} />, { wrapper });
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveTextContent('Chargement…');
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('devrait avoir aria-busy={true} pendant la mutation', () => {
+    (useCheckout as ReturnType<typeof vi.fn>).mockReturnValue({
+      startCheckout: mockStartCheckout,
+      isPending: true,
+      error: null,
+    });
+
+    render(<UpgradeButton plan={PLANS.PLUS} />, { wrapper });
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('devrait avoir aria-label explicite', () => {
+    render(<UpgradeButton plan={PLANS.PLUS} />, { wrapper });
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-label', 'Passer au plan Plus');
+  });
+
+  it("devrait ignorer le double-clic (pas d'appel supplémentaire si isPending)", async () => {
+    (useCheckout as ReturnType<typeof vi.fn>).mockReturnValue({
+      startCheckout: mockStartCheckout,
+      isPending: true,
+      error: null,
+    });
+
+    render(<UpgradeButton plan={PLANS.PLUS} />, { wrapper });
+
+    const button = screen.getByRole('button');
+    button.click();
+    button.click(); // Second clic (doit être ignoré)
+
+    await waitFor(() => {
+      expect(mockStartCheckout).not.toHaveBeenCalled();
+    });
+  });
+
+  it('devrait appeler onBeforeCheckout et peut annuler si retourne false', async () => {
+    const onBeforeCheckout = vi.fn().mockReturnValue(false);
+
+    render(
+      <UpgradeButton plan={PLANS.PLUS} onBeforeCheckout={onBeforeCheckout} />,
+      {
+        wrapper,
+      }
+    );
+
+    const button = screen.getByRole('button');
+    button.click();
+
+    await waitFor(() => {
+      expect(onBeforeCheckout).toHaveBeenCalled();
+    });
+
+    // Le checkout ne doit pas être appelé si onBeforeCheckout retourne false
+    expect(mockStartCheckout).not.toHaveBeenCalled();
+  });
+
+  it('devrait appeler startCheckout si onBeforeCheckout ne retourne pas false', async () => {
+    const onBeforeCheckout = vi.fn().mockReturnValue(true);
+
+    render(
+      <UpgradeButton plan={PLANS.PLUS} onBeforeCheckout={onBeforeCheckout} />,
+      {
+        wrapper,
+      }
+    );
+
+    const button = screen.getByRole('button');
+    button.click();
+
+    await waitFor(() => {
+      expect(onBeforeCheckout).toHaveBeenCalled();
+      expect(mockStartCheckout).toHaveBeenCalledWith(PLANS.PLUS);
+    });
+  });
+
+  it('devrait fonctionner avec plan PRO', () => {
+    render(<UpgradeButton plan={PLANS.PRO} />, { wrapper });
+
+    expect(screen.getByText(/Passer au plan Pro/i)).toBeInTheDocument();
+  });
+
+  it('devrait supporter la variante secondary', () => {
+    render(<UpgradeButton plan={PLANS.PLUS} variant="secondary" />, {
+      wrapper,
+    });
+
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+  });
+});

--- a/src/widgets/UpgradeButton/UpgradeButton.tsx
+++ b/src/widgets/UpgradeButton/UpgradeButton.tsx
@@ -1,0 +1,90 @@
+import { useCheckout } from '@/features/billing/hooks/useCheckout';
+import { PLAN_LABELS, type BillingPlan } from '@/shared/config/plans';
+
+/**
+ * Props pour le composant UpgradeButton
+ */
+export interface UpgradeButtonProps {
+  /** Plan de facturation (plus | pro) */
+  plan: BillingPlan;
+  /** Label personnalisé (défaut depuis PLAN_LABELS) */
+  label?: string;
+  /** Variante du bouton */
+  variant?: 'primary' | 'secondary';
+  /** Callback optionnel appelé avant checkout (peut annuler si retourne false) */
+  onBeforeCheckout?: () => boolean | void;
+}
+
+/**
+ * Composant réutilisable pour bouton upgrade vers un plan de facturation
+ * Utilise useCheckout() pour créer session Stripe et rediriger
+ * Gère l'état pending avec disabled et aria-busy
+ */
+export function UpgradeButton({
+  plan,
+  label,
+  variant = 'primary',
+  onBeforeCheckout,
+}: UpgradeButtonProps): JSX.Element {
+  const { startCheckout, isPending } = useCheckout();
+
+  // Label par défaut depuis PLAN_LABELS
+  const buttonLabel = label ?? PLAN_LABELS[plan];
+  const displayLabel = isPending
+    ? 'Chargement…'
+    : `Passer au plan ${buttonLabel}`;
+
+  const handleClick = (): void => {
+    // Ignore les clics si pending
+    if (isPending) {
+      return;
+    }
+
+    // Appeler onBeforeCheckout si fourni (peut annuler si retourne false)
+    if (onBeforeCheckout?.() === false) {
+      return;
+    }
+
+    // Démarrer le checkout
+    void startCheckout(plan);
+  };
+
+  const baseStyle: React.CSSProperties = {
+    padding: '0.5rem 1rem',
+    border: 'none',
+    borderRadius: '0.25rem',
+    cursor: isPending ? 'not-allowed' : 'pointer',
+    fontWeight: 500,
+    transition: 'opacity 0.2s',
+    opacity: isPending ? 0.7 : 1,
+  };
+
+  const variantStyles: Record<'primary' | 'secondary', React.CSSProperties> = {
+    primary: {
+      backgroundColor: '#f59e0b',
+      color: 'white',
+    },
+    secondary: {
+      backgroundColor: 'transparent',
+      color: '#f59e0b',
+      border: '1px solid #f59e0b',
+    },
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={isPending}
+      aria-busy={isPending}
+      aria-label={`Passer au plan ${buttonLabel}`}
+      title={`Passer au plan ${buttonLabel} pour accéder à plus de fonctionnalités`}
+      style={{
+        ...baseStyle,
+        ...variantStyles[variant],
+      }}
+    >
+      {displayLabel}
+    </button>
+  );
+}


### PR DESCRIPTION
## Description

Implémentation complète du système de checkout et portail billing pour les plans Plus/Pro.

## Changements

### Nouvelles fonctionnalités
- BillingService: createCheckoutSession(plan, idemKey) et createPortalSession()
- Hooks: useCheckout et usePortal avec protection double-clic
- Widgets: UpgradeButton et PortalButton réutilisables
- Intégration: Boutons dans PrivateLayout (header) et DashboardPage
- Revalidation: Queries paywall revalidées au retour de Stripe

### Détails techniques
- Idempotency-Key générée au clic (UUID v4)
- Validation Zod stricte pour les réponses API
- Redirection via window.location.assign
- Gestion d'erreurs complète (401, 409, NetworkError)
- Protection double-clic dans les hooks

## Tests
- 184 tests passent (100%)
- Tests service, hooks, widgets
- Tests idempotency, double-clic, redirection, erreurs
- Aucune erreur de linting

Closes #12